### PR TITLE
core: Disable /xmlrpc.php URL entirely

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -48,6 +48,16 @@ RewriteRule   ^/?myao.php       /wp-login.php   [R=302,L]
 
 
 
+### Disable /xmlrpc.php
+#
+# This file is a security liability.
+# The reason we keep this file around is because WordPress updates keep bringing
+# it back. Therefore, we simply redirect to a substitute handler.
+#
+RewriteRule   ^/?xmlrpc.php       /xmlrpc-disabled.php   [L]
+
+
+
 ### Final redirect to WP handler
 #
 RewriteRule ^index\.php$ - [L]

--- a/public/xmlrpc-disabled.php
+++ b/public/xmlrpc-disabled.php
@@ -1,0 +1,3 @@
+<?php
+
+header('HTTP/1.1 503 Disabled');


### PR DESCRIPTION
This file is a security liability.
The reason we keep this file around is because WordPress updates keep bringing
it back. Therefore, we simply redirect to a substitute handler.

@JNastran, a slucajno kej ves, ce bi se to se za kej rablo?

Kolikor sem preskeniral naso WordPress kodo (core in plugine), je vsa koda samo za podporo XML-RPC-ju, ampak izgleda da vsa komunikacija ze prenesena na REST API.