### PR TITLE
uploads: Implement on-the-fly fetching of wp-content/uploads on non-prod environments

### DIFF
--- a/doc/docker-dev-environment.md
+++ b/doc/docker-dev-environment.md
@@ -39,7 +39,7 @@ Step #4 - Start the Docker-based dev environment:
 
 Step #5 - dump+import the staging database:
 ```
-ssh ao-stg@stg.aokranj.com ./www/stg.aokranj.com/sbin/db-dump | ./sbin/wp-in-docker db import -
+ssh stg.aokranj.com /data/ao-stg/stg.aokranj.com/sbin/db-dump | ./sbin/wp-in-docker db import -
 ```
 
 
@@ -49,15 +49,20 @@ Step #6 - Fix the URLs in the new database copy
 ```
 
 
-Step #7 - Fetch the `public/wp-content/uploads` content
+Step #7 - Run the `sbin/deploy-here` script (to set up & verify all permissions)
 ```
-rsync -av ao-stg@stg.aokranj.com:www/stg.aokranj.com/public/wp-content/uploads/ public/wp-content/uploads/
+./sbin/deploy-here
 ```
 
 
-Step #8 - Fix the `public/wp-content/uploads` permissions:
+Step #8a - No need to fetch `public/wp-content/uploads` content:
+- Our tool [public/fetch-upload-from-prod.php](../public/fetch-upload-from-prod.php) fetches all required files on-the-fly
+
+
+Step #8b - ALTERNATIVE to 8a - Fetch the `public/wp-content/uploads` content
 ```
-chmod -R 777 public/wp-content/uploads
+rsync -av stg.aokranj.com:/data/ao-stg/stg.aokranj.com/public/wp-content/uploads/  public/wp-content/uploads/   # From STG
+rsync -av www.aokranj.com:/data/ao-prod/www.aokranj.com/public/wp-content/uploads/ public/wp-content/uploads/   # From PROD
 ```
 
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -58,6 +58,18 @@ RewriteRule   ^/?xmlrpc.php       /xmlrpc-disabled.php   [L]
 
 
 
+### Fetch missing files from /wp-content/upload
+#
+# On a non-production clone, if a request hits 
+#
+RewriteCond     %{HTTP_HOST}            !^www\.aokranj\.com$
+RewriteCond     %{REQUEST_URI}          ^/wp-content/uploads/
+RewriteCond     %{REQUEST_FILENAME}     !-f
+RewriteCond     %{REQUEST_FILENAME}     !-d
+RewriteRule     ^/?(.+)$                /fetch-upload-from-prod.php?path=$1     [L]
+
+
+
 ### Final redirect to WP handler
 #
 RewriteRule ^index\.php$ - [L]

--- a/public/fetch-upload-from-prod.php
+++ b/public/fetch-upload-from-prod.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Retrieve missing wp-content/uploads/... files from production on-the-fly (and store it locally, and serve it to the client too)
+ *
+ * Instead of implementing a fancy tool that determines what files it should fetch
+ * and fetch those files in advance, let's just capture the requests that would
+ * have generated a 404 error in the wp-content/uploads/ directory, and handle
+ * those requests by fetching the file from prod, storing it locally and serving
+ * the said file back to the client too.
+ *
+ * With the exception of a slight delay on the first run, such handling should
+ * make fetching uploads transparent to our user (provided they have a working
+ * internet connection).
+ */
+
+
+/*
+ * Init Wordpress
+ */
+$wp_did_header = true;
+require_once __DIR__ . '/wp-load.php';
+
+
+/*
+ * Parse & verify the argument
+ */
+$filePath = $_GET["path"];   // Without leading slash
+
+if (!preg_match('#^(wp-content/uploads/.+)/([^/]+)$#', $filePath, $m)) {
+    throw new Exception("Unsupported path: $filePath");
+}
+$fileDir  = $m[1];
+$fileName = $m[2];
+$prodUrl  = "https://www.aokranj.com/" . $filePath;
+
+/*
+ * Check & create the directory
+ */
+if (!file_exists($fileDir)) {
+    mkdir($fileDir, 0777, true);
+} else {
+    if (!is_dir($fileDir)) {
+        throw new Exception("Not a directory: $fileDir");
+    }
+}
+
+
+/*
+ * Fetch the file from prod
+ */
+$response = wp_remote_get($prodUrl);
+if (wp_remote_retrieve_response_code($response) != 200) {
+    throw new Exception("Unable to retrieve remote resource: $prodUrl");
+}
+
+
+/*
+ * Store the file locally
+ */
+$body = wp_remote_retrieve_body($response);
+file_put_contents($filePath, $body);
+
+
+/*
+ * Pass the file content (and the correct content-type header) to the client
+ */
+header("content-type: ". $response['headers']['content-type']);
+echo $body;


### PR DESCRIPTION
Torej, tole deluje takole:
- Ce je request na ne-`www.aokranj.com` hostu (torej na stg, dev okoljih)
- Ce je request prefix `wp-content/uploads/`
- Ce requested file ne obstaja lokalno (in bi toraj generiral 404 napako)
- Potegni content iz `www.aokranj.com/wp-content/uploads/...`
- Shrani content v `wp-content/uploads/...` (na isti lokaciji kot je bila requestana)
- Serviraj content clientu (s pravim `content-type` headerjem)

Pros:
- Ni treba več ročno kopirati `wp-content/uploads` vsebine

Cons:
- Prvi page load-i trajajo nekoliko dlje, ker se content kopira iz produkcije
- Potrebuje internetno povezavo (predvsem docker-based dev okolje)
- www.aokranj.com mora delat

Lahko preverita delovanje na https://b.dev.aokranj.com, kjer sem ravno prejle zbrisal celotno vsebino `public/wp-content/uploads`.
