### PR TITLE
docker dev environment setup changes

### DIFF
--- a/doc/docker-dev-environment.md
+++ b/doc/docker-dev-environment.md
@@ -22,12 +22,12 @@ cd website-aokranj.com
 ```
 
 
-Step #3 - Configure your `conf/wp-config.php` file.
-The `conf/wp-config.php.SAMPLE` file is already preconfigured for this use case,
+Step #3 - Configure your `conf/wp-config-local.php` file.
+The `conf/wp-config-local.php.SAMPLE` file is already preconfigured for this use case,
 so just get a new set of salts [here](https://api.wordpress.org/secret-key/1.1/salt/) and you're done:
 ```
-cp conf/wp-config.php.SAMPLE conf/wp-config.php
-edit conf/wp-config.php
+cp conf/wp-config-local.php.SAMPLE conf/wp-config-local.php
+edit conf/wp-config-local.php
 ```
 
 
@@ -49,9 +49,14 @@ Step #6 - Fix the URLs in the new database copy
 ```
 
 
-Step #7 - Run the `sbin/deploy-here` script (to set up & verify all permissions)
+Step #7a - Run the `sbin/deploy-here` script (to set up & verify all permissions)
 ```
 ./sbin/deploy-here
+```
+
+Step #7b - ALTERNATIVE to 7a - Run the `sbin/deploy-in-docker` script (runs `sbin/deploy-here` in Docker)
+```
+./sbin/deploy-in-docker
 ```
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     container_name: 'aokranj-phpmyadmin'
     image: phpmyadmin/phpmyadmin:latest
     depends_on:
-      - aokranj-mariadb
+      - mariadb
     environment:
       PMA_HOST: mariadb
       PMA_PORT: 3306

--- a/sbin/deploy-in-docker
+++ b/sbin/deploy-in-docker
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -i -e WP_CLI_ALLOW_ROOT=value aokranj-webserver ./sbin/deploy-here


### PR DESCRIPTION
1. Nekaj sprememb v `doc/docker-dev-environment.md`
2. Popravek v `docker/docker-compose.yml`
3. Dodal `sbin/deploy-in-docker`. Tu notri sem v docker exec dodal env variablo `WP_CLI_ALLOW_ROOT=value`. Razlog da ima vrednost `value`, je ker ima zgleda php koda od wp-cli notri if getenv() [pogoj](https://github.com/wp-cli/wp-cli/blob/7914bc4fdd5461da83da10358e36dcecd4444cc2/php/WP_CLI/Runner.php#L981). getenv() funkcija pa zgleda, da ne vrne true če env variabla nima vrednosti. Ostale `--allow-root` v skriptah sem pa zaenkrat pustil pri miru.