### PR TITLE
Define default theme to make a site health check go away

### DIFF
--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -58,6 +58,7 @@ if (!defined('DB_COLLATE')) define('DB_COLLATE', 'utf8_slovenian_ci');
 if (!defined('WPLANG'))     define('WPLANG',     'sl_SI');
 if (!defined('WP_DEBUG'))   define('WP_DEBUG',   false);
 if (!isset($table_prefix))  $table_prefix = 'wp_';
+if (!defined('WP_DEFAULT_THEME')) define('WP_DEFAULT_THEME', 'aokranj'); // Defined to make the health check stop complaining about the missing default theme (which we removed)
 
 /*
  * Site URL _must_ be defined in the configuration


### PR DESCRIPTION
In WP admin, at URL /wp-admin/site-health.php, a `Have a default theme available` message is annoying us all the time if (the default) `WP_DEFAULT_THEME` is missing (which it is, since we've deleted it).

To hide the bogus warning, let's redefine the WP_DEFAULT_THEME from its default value (`twenty...` something) to `aokranj`.